### PR TITLE
ci(workflows): synchronize workflows from JanssenProject/jans-cloud-native

### DIFF
--- a/.github/workflows/central_code_quality_check.yml
+++ b/.github/workflows/central_code_quality_check.yml
@@ -8,24 +8,25 @@ on:
     branches:
       - master
       - main
-      - "!update-pycloud-in-**"
-    paths:
-      - "!docker-jans-**/CHANGELOG.md"
-      - "!docker-jans-**/version.txt"
-      - "!jans-pycloudlib/CHANGELOG.md"
-      - "!jans-pycloudlib/jans/pycloudlib/version.py"
-      - "!**.md"
+      - "!update-pycloud-in-**"      
+    paths-ignore:
+      - 'docker-jans-**/CHANGELOG.md'
+      - 'docker-jans-**/version.txt'
+      - 'jans-pycloudlib/CHANGELOG.md'
+      - 'jans-pycloudlib/jans/pycloudlib/version.py'
+      - '**.md'
+
   pull_request:
     branches:
       - master
       - main
-      - "!update-pycloud-in-**"
-    paths:
-      - "!docker-jans-**/CHANGELOG.md"
-      - "!docker-jans-**/version.txt"
-      - "!jans-pycloudlib/CHANGELOG.md"
-      - "!jans-pycloudlib/jans/pycloudlib/version.py"
-      - "!**.md"
+      - "!update-pycloud-in-**"      
+    paths-ignore:
+      - 'docker-jans-**/CHANGELOG.md'
+      - 'docker-jans-**/version.txt'
+      - 'jans-pycloudlib/CHANGELOG.md'
+      - 'jans-pycloudlib/jans/pycloudlib/version.py'
+      - '**.md'
   workflow_dispatch:
 jobs:
   build:
@@ -53,7 +54,7 @@ jobs:
       - name: Set up JDK 11
         # JanssenProject/jans-cli is too similar to JanssenProject/jans-client-api as the contains function is returning it belonging to the JVM_PROJECT
         if: contains(env.JVM_PROJECTS, github.repository) && github.repository != 'JanssenProject/jans-cli'
-        uses: actions/setup-java@v2.4.0
+        uses: actions/setup-java@v2.5.0
         with:
           java-version: '11'
           distribution: 'adopt'


### PR DESCRIPTION
Propagating changes from JanssenProject/jans-cloud-native default branch.